### PR TITLE
Replace Gregorian calendar with Ethiopian

### DIFF
--- a/app/src/main/java/org/dhis2/customui/EthiopianDateUtils.kt
+++ b/app/src/main/java/org/dhis2/customui/EthiopianDateUtils.kt
@@ -15,9 +15,17 @@ object EthiopianDateUtils {
     )
 
     fun formatEthiopianDate(date: Date): String {
-        val ethioDate = EthiopianDateConverter.gregorianToEthiopian(date)
+        val ethioDate = org.dhis2.commons.periods.data.EthiopianDateConverter.gregorianToEthiopian(date)
         return "${ethiopianMonthNames[ethioDate.month - 1]} ${ethioDate.day}, ${ethioDate.year}"
-
+    }
+    
+    /**
+     * Get the current biweekly period for today's date
+     * This ensures consistency when retrieving current period data
+     */
+    fun getCurrentBiWeeklyPeriod(): EthiopianPeriod {
+        val today = org.dhis2.commons.periods.data.EthiopianDateConverter.gregorianToEthiopian(Date())
+        return getBiWeeklyPeriodForDate(today)
     }
 
     fun getEthiopianPeriods(
@@ -28,8 +36,8 @@ object EthiopianDateUtils {
         displayFromYear: Int? = null
     ): List<EthiopianPeriod> {
         val baseDate = selectedDate ?: Date()
-        val baseEthioDate = EthiopianDateConverter.gregorianToEthiopian(baseDate)
-        val currentEthYear = EthiopianDateConverter.gregorianToEthiopian(Date()).year
+        val baseEthioDate = org.dhis2.commons.periods.data.EthiopianDateConverter.gregorianToEthiopian(baseDate)
+        val currentEthYear = org.dhis2.commons.periods.data.EthiopianDateConverter.gregorianToEthiopian(Date()).year
 
         val periods = when (periodType) {
             PeriodType.Daily -> generateDailyPeriods(baseEthioDate, currentEthYear, minYear, openFuturePeriods)
@@ -138,36 +146,68 @@ object EthiopianDateUtils {
         futurePeriods: Int
     ): List<EthiopianPeriod> {
         val periods = mutableListOf<EthiopianPeriod>()
-        val totalBiWeeksInYear = 26 // 52 weeks / 2 = 26 biweeks
-        val currentBiWeek = calculateBiWeekOfYear(baseDate)
-
-        for (year in minYear..currentYear) {
-            val maxBiWeeks = if (year == currentYear) min(currentBiWeek + futurePeriods, totalBiWeeksInYear) else totalBiWeeksInYear
-
-            for (biWeek in 1..maxBiWeeks) {
-                val startDay = (biWeek - 1) * 14 + 1
-                val endDay = min(biWeek * 14, if (year % 4 == 3) 366 else 365)
-
-                val startEthDate =  EthiopianDateConverter.dayOfYearToEthiopianDate(year, startDay)
-                val endEthDate =  EthiopianDateConverter.dayOfYearToEthiopianDate(year, endDay)
-
+        
+        // Ethiopian calendar: Each year has 365 days (366 in leap year)
+        // BiWeekly periods start from Meskerem 1 (start of Ethiopian year)
+        for (year in minYear..currentYear + futurePeriods) {
+            if (year > currentYear + futurePeriods) break
+            
+            // Calculate how many biweekly periods to generate for this year
+            val isCurrentYear = (year == currentYear)
+            val currentDayOfYear = if (isCurrentYear) calculateDayOfYear(baseDate) else 365
+            val maxBiWeeksInYear = if (year % 4 == 3) 26 else 26 // 365/14 = 26 biweeks per year
+            
+            for (biWeekNum in 1..maxBiWeeksInYear) {
+                val startDay = (biWeekNum - 1) * 14 + 1
+                val endDay = min(biWeekNum * 14, if (year % 4 == 3) 366 else 365)
+                
+                // Only include periods up to current date + future periods
+                if (isCurrentYear && startDay > currentDayOfYear + (futurePeriods * 14)) break
+                
+                val startEthDate = org.dhis2.commons.periods.data.EthiopianDateConverter.dayOfYearToEthiopianDate(year, startDay)
+                val endEthDate = org.dhis2.commons.periods.data.EthiopianDateConverter.dayOfYearToEthiopianDate(year, endDay)
+                
+                // Ensure consistent labeling
                 val label = buildBiWeeklyLabel(startEthDate, endEthDate, year)
-
-                val startDate = EthiopianDateConverter.ethiopianToGregorian(
+                
+                val startDate = org.dhis2.commons.periods.data.EthiopianDateConverter.ethiopianToGregorian(
                     startEthDate.year,
                     startEthDate.month,
                     startEthDate.day
                 )
+                
                 periods.add(EthiopianPeriod(startDate, label))
             }
         }
 
-        return periods
+        return periods.sortedBy { it.startDate }
     }
 
     private fun calculateBiWeekOfYear(date: EthiopianDate): Int {
         val dayOfYear = calculateDayOfYear(date)
         return (dayOfYear - 1) / 14 + 1
+    }
+    
+    /**
+     * Get the biweekly period that contains the given Ethiopian date
+     * This ensures consistency between display and retrieval
+     */
+    fun getBiWeeklyPeriodForDate(date: EthiopianDate): EthiopianPeriod {
+        val biWeekNum = calculateBiWeekOfYear(date)
+        val startDay = (biWeekNum - 1) * 14 + 1
+        val endDay = min(biWeekNum * 14, if (date.year % 4 == 3) 366 else 365)
+        
+        val startEthDate = org.dhis2.commons.periods.data.EthiopianDateConverter.dayOfYearToEthiopianDate(date.year, startDay)
+        val endEthDate = org.dhis2.commons.periods.data.EthiopianDateConverter.dayOfYearToEthiopianDate(date.year, endDay)
+        
+        val label = buildBiWeeklyLabel(startEthDate, endEthDate, date.year)
+        val startDate = org.dhis2.commons.periods.data.EthiopianDateConverter.ethiopianToGregorian(
+            startEthDate.year,
+            startEthDate.month,
+            startEthDate.day
+        )
+        
+        return EthiopianPeriod(startDate, label)
     }
 
     private fun calculateDayOfYear(date: EthiopianDate): Int {
@@ -188,11 +228,16 @@ object EthiopianDateUtils {
         endDate: EthiopianDate,
         year: Int
     ): String {
+        // Create consistent biweekly labels using standard format
+        val startMonthName = ethiopianMonthNames[startDate.month - 1]
+        val endMonthName = ethiopianMonthNames[endDate.month - 1]
+        
         return if (startDate.month == endDate.month) {
-            "${ethiopianMonthNames[startDate.month - 1]} ${startDate.day}-${endDate.day}, $year"
+            // Same month: "Meskerem 1-14, 2015"
+            "$startMonthName ${startDate.day}-${endDate.day}, $year"
         } else {
-            "${ethiopianMonthNames[startDate.month - 1]} ${startDate.day}-" +
-                    "${ethiopianMonthNames[endDate.month - 1]} ${endDate.day}, $year"
+            // Different months: "Nehase 16 - Meskerem 1, 2015" 
+            "$startMonthName ${startDate.day} - $endMonthName ${endDate.day}, $year"
         }
     }
     private fun generateMonthlyPeriods(

--- a/commons/src/main/java/org/dhis2/commons/date/EthiopianDateConverter.kt
+++ b/commons/src/main/java/org/dhis2/commons/date/EthiopianDateConverter.kt
@@ -1,36 +1,99 @@
 package org.dhis2.commons.date
 
 import java.util.Calendar
+import java.util.Date
 
 object EthiopianDateConverter {
     // Ethiopian calendar constants
-    private const val ETH_TO_GREG_OFFSET = 8
-    private const val ETH_MONTH_OFFSET = 3
-    private const val ETH_NEW_YEAR = 11 // Ethiopian New Year is September 11/12
+    private const val ETH_TO_GREG_OFFSET = 8 // Ethiopian year is typically 7-8 years behind Gregorian
+    
+    // Ethiopian months have 30 days each, except the 13th month (Pagume) which has 5 or 6 days
+    private val ETHIOPIAN_MONTH_NAMES = arrayOf(
+        "መስከረም", "ጥቅምት", "ህዳር", "ታህሳስ", "ጥር", "የካቲት",
+        "መጋቢት", "ሚያዝያ", "ግንቦት", "ሰኔ", "ሐምሌ", "ነሐሴ", "ጳጉሜ"
+    )
 
+    /**
+     * Converts Ethiopian date to Gregorian Calendar
+     */
     fun toGregorian(ethYear: Int, ethMonth: Int, ethDay: Int): Calendar {
-        val gregDate = Calendar.getInstance().apply {
-            // Convert Ethiopian date to Gregorian
-            val gregYear = ethYear + ETH_TO_GREG_OFFSET
-            val gregMonth = (ethMonth + ETH_MONTH_OFFSET) % 12
-            val gregDay = ethDay
-
-            set(Calendar.YEAR, gregYear)
-            set(Calendar.MONTH, if (gregMonth == 0) Calendar.SEPTEMBER else gregMonth - 1)
-            set(Calendar.DAY_OF_MONTH, gregDay)
-        }
+        val gregDate = Calendar.getInstance()
+        
+        // Ethiopian New Year (1 Meskerem) typically falls on September 11 (12 in leap year)
+        // Calculate the number of days from Ethiopian epoch
+        val ethiopianDays = (ethYear - 1) * 365 + ((ethYear - 1) / 4) + // years and leap days
+                          (ethMonth - 1) * 30 + ethDay - 1 // months and days
+        
+        // Set to Ethiopian New Year base date (September 11, for the given Gregorian year)
+        val baseYear = ethYear + ETH_TO_GREG_OFFSET
+        gregDate.set(baseYear, Calendar.SEPTEMBER, 11, 0, 0, 0)
+        gregDate.set(Calendar.MILLISECOND, 0)
+        
+        // Add the calculated days
+        val totalDaysFromNewYear = (ethMonth - 1) * 30 + ethDay - 1
+        gregDate.add(Calendar.DAY_OF_YEAR, totalDaysFromNewYear)
+        
         return gregDate
     }
 
+    /**
+     * Converts Gregorian Calendar to Ethiopian date (year, month, day)
+     */
     fun toEthiopian(gregDate: Calendar): Triple<Int, Int, Int> {
-        // Convert Gregorian date to Ethiopian
-        val gregYear = gregDate.get(Calendar.YEAR)
-        val ethYear = gregYear - ETH_TO_GREG_OFFSET
+        val year = gregDate.get(Calendar.YEAR)
+        val month = gregDate.get(Calendar.MONTH) // 0-based
+        val day = gregDate.get(Calendar.DAY_OF_MONTH)
+        
+        // Determine Ethiopian year based on Gregorian date
+        val ethYear = if (month >= Calendar.SEPTEMBER) {
+            // After September, we're in the new Ethiopian year
+            year - ETH_TO_GREG_OFFSET + 1
+        } else {
+            // Before September, we're still in the previous Ethiopian year
+            year - ETH_TO_GREG_OFFSET
+        }
+        
+        // Calculate Ethiopian New Year for this Ethiopian year
+        val ethiopianNewYear = Calendar.getInstance()
+        ethiopianNewYear.set(year - (if (month >= Calendar.SEPTEMBER) 0 else 1), Calendar.SEPTEMBER, 11, 0, 0, 0)
+        ethiopianNewYear.set(Calendar.MILLISECOND, 0)
+        
+        // Calculate days difference from Ethiopian New Year
+        val diffInMillis = gregDate.timeInMillis - ethiopianNewYear.timeInMillis
+        val daysSinceNewYear = (diffInMillis / (24 * 60 * 60 * 1000)).toInt()
+        
+        // Calculate Ethiopian month and day
+        val ethMonth = (daysSinceNewYear / 30) + 1
+        val ethDay = (daysSinceNewYear % 30) + 1
+        
+        // Handle edge cases for the 13th month (Pagume)
+        if (ethMonth > 13) {
+            return Triple(ethYear + 1, 1, ethDay - 30)
+        }
+        
+        return Triple(ethYear, ethMonth, ethDay)
+    }
 
-        val gregMonth = gregDate.get(Calendar.MONTH) + 1
-        val ethMonth = (gregMonth - ETH_MONTH_OFFSET + 12) % 12
-        val ethDay = gregDate.get(Calendar.DAY_OF_MONTH)
+    /**
+     * Converts Java Date to Ethiopian date
+     */
+    fun gregorianToEthiopian(date: Date): Triple<Int, Int, Int> {
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        return toEthiopian(calendar)
+    }
 
-        return Triple(ethYear, if (ethMonth == 0) 12 else ethMonth, ethDay)
+    /**
+     * Formats Ethiopian date as string
+     */
+    fun formatEthiopianDate(ethYear: Int, ethMonth: Int, ethDay: Int): String {
+        return String.format("%02d/%02d/%04d", ethDay, ethMonth, ethYear)
+    }
+
+    /**
+     * Gets Ethiopian month name
+     */
+    fun getEthiopianMonthName(month: Int): String {
+        return if (month in 1..13) ETHIOPIAN_MONTH_NAMES[month - 1] else "Unknown"
     }
 }

--- a/commons/src/main/java/org/dhis2/commons/dialogs/calendarpicker/CalendarPicker.kt
+++ b/commons/src/main/java/org/dhis2/commons/dialogs/calendarpicker/CalendarPicker.kt
@@ -82,6 +82,13 @@ class CalendarPicker(
         if (listener == null) {
             throw IllegalArgumentException("Listener must be set up")
         }
+        
+        // If Ethiopian calendar is enabled, show Ethiopian date picker directly
+        if (repository.isEthiopianEnabled()) {
+            showEthiopianDatePicker()
+            return
+        }
+        
         setCalendar()
         datePickerVisibility(repository.isDatePickerStyle())
         setFuturesDates()


### PR DESCRIPTION
```
## Description

This PR addresses the consistency of biweekly periods when using the Ethiopian calendar, ensuring that displayed periods match retrieved data. It also sets the Ethiopian calendar as the default in the calendar picker when enabled.

[JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-XXXX)

## Solution Description

*   **Refactored `EthiopianDateConverter`**: Improved the accuracy and robustness of Gregorian-to-Ethiopian and Ethiopian-to-Gregorian date conversions.
*   **Consistent Biweekly Logic**: Updated `EthiopianDateUtils.kt` to generate biweekly periods and labels consistently, ensuring that the start and end dates of a biweekly period are the same for both display and data retrieval. New utility methods (`getCurrentBiWeeklyPeriod`, `getBiWeeklyPeriodForDate`) were added for this purpose.
*   **Default Ethiopian Calendar**: Modified `CalendarPicker.kt` to directly show the Ethiopian date picker if the Ethiopian calendar is enabled in the repository settings, making it the default view.

## Title Format

feat: [ANDROAPP-XXXX] Implement consistent Ethiopian biweekly periods and default Ethiopian calendar
```

---
<a href="https://cursor.com/background-agent?bcId=bc-6d32a13e-797e-4ae6-9441-f16ee8cf67cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d32a13e-797e-4ae6-9441-f16ee8cf67cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>